### PR TITLE
Add Docker compatibility 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,21 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt-get update \
     && apt-get install -y nodejs
 
+# Install R
+RUN apt-key adv --keyserver keys.gnupg.net --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF'
+RUN echo 'deb http://cran.rstudio.org/bin/linux/debian jessie-cran34/'
+RUN apt-get update && apt-get install -y r-base
+
+# Install R libs
+RUN Rscript -e "install.packages(c('seriation', 'jsonlite'), repos='http://cran.rstudio.org')"
+RUN Rscript -e "source('http://bioconductor.org/biocLite.R'); biocLite('limma'); biocLite('edgeR')"
+
 # Copy degust into the container
 ADD . /opt/degust
 WORKDIR /opt/degust
 
 # Run setup tasks
+RUN mkdir -p uploads log tmp/pids tmp/cache tmp/sockets tmp/R-cache
 RUN bundle install
 RUN rake degust:deps
 RUN rake degust:build RAILS_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ruby:2.4.0
+
+# Install NodeJS (6.X, LTS)
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \ 
+    && apt-get update \
+    && apt-get install -y nodejs
+
+# Copy degust into the container
+ADD . /opt/degust
+WORKDIR /opt/degust
+
+# Run setup tasks
+RUN bundle install
+RUN rake degust:deps
+RUN rake degust:build RAILS_ENV=production
+RUN rake db:migrate
+
+# Run server
+CMD rails s -p 3000 -b '0.0.0.0'

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,39 +1,9 @@
-Install
----------------
+# Install
+Degust can be installed natively or using Docker.
 
-Ensure rails 4.2 is installed.  Install the necessary gems:
+## Native
 
-    bundle install
-
-Build the js frontend
-
-    rake degust:deps
-    rake degust:build
-
-For production build (minifies js, and no source-maps)
-
-    rake degust:build RAILS_ENV=production
-
-
-For development:
-
-    (cd degust-frontend ; ./node_modules/.bin/grunt build)
-    (cd degust-frontend ; ./node_modules/.bin/grunt watch)
-    rails s
-
-
-For production deploy.  Configure `config/deploy/production.rb`
-
-    cap production deploy
-
-
-
-
-
-
-
-Using rbenv
-----------
+### Install Ruby using rbenv (optional)
 
 As the install user:
   git clone https://github.com/rbenv/rbenv.git ~/.rbenv
@@ -55,5 +25,42 @@ And use it
 Install bundler
   gem install bundler
 
+### Install Degust
 
+Ensure rails 4.2 is installed.  Install the necessary gems:
 
+    bundle install
+
+Build the js frontend
+
+    rake degust:deps
+    rake degust:build
+
+For production build (minifies js, and no source-maps)
+
+    rake degust:build RAILS_ENV=production
+
+For development:
+
+    (cd degust-frontend ; ./node_modules/.bin/grunt build)
+    (cd degust-frontend ; ./node_modules/.bin/grunt watch)
+    rails s
+
+For production deploy.  Configure `config/deploy/production.rb`
+
+    cap production deploy
+
+## Docker
+Ensure Docker is installed, clone this repository, and then from inside the cloned
+repository, run:
+
+    docker build . --tag degust
+
+Once the build process has completed, you will have a docker image tagged as "degust" on your system.
+To run this container, run:
+
+    docker run -p 80:3000 degust
+
+This will start degust in the docker container, and allow access to the container via port 80 on your machine.
+To access the website, go to `http://localhost/` on your web browser. You can change `80` to any port you wish 
+to have degust listening on.


### PR DESCRIPTION
Adding Docker compatibility should make it somewhat quicker/simpler for users to install and run Degust, and remove the need for them to install Ruby, node, R etc. onto their system 

Changes:
* Add `Dockerfile` for automated Docker builds
* Update `INSTALL.md` to include Docker installation