### PR TITLE
Update Dockerfile to use debian archive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM ruby:2.4.0
 
+RUN echo "deb http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
+RUN echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/100disablechecks
+
 # Install NodeJS (6.X, LTS)
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \ 
     && apt-get update \


### PR DESCRIPTION
Current dockerfile will not build because [Wheezy and Jessie have been integrated into the archive.debian.org ](https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html)

Changes will use the archive repository instead