### PR TITLE
Feature: Add GitHub as an authentication provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'high_voltage'
 gem 'omniauth'
 gem 'omniauth-twitter'
 gem 'omniauth-google-oauth2'
+gem 'omniauth-github'
 gem 'simple_form'
 
 gem 'browser-timezone-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,9 @@ GEM
     omniauth (1.8.1)
       hashie (>= 3.4.6, < 3.6.0)
       rack (>= 1.6.2, < 3)
+    omniauth-github (1.4.0)
+      omniauth (~> 1.5)
+      omniauth-oauth2 (>= 1.4.0, < 2.0)
     omniauth-google-oauth2 (0.5.3)
       jwt (>= 1.5)
       omniauth (>= 1.1.1)
@@ -261,6 +264,7 @@ DEPENDENCIES
   loofah (>= 2.2.3)
   nokogiri (>= 1.8.5)
   omniauth
+  omniauth-github
   omniauth-google-oauth2
   omniauth-twitter
   puma (~> 3.0)

--- a/app/views/layouts/_nav_links_for_auth.html.haml
+++ b/app/views/layouts/_nav_links_for_auth.html.haml
@@ -22,6 +22,8 @@
         = link_to "Via Twitter", "/auth/twitter"
       %li
         = link_to "Via Google", "/auth/google_oauth2"
+      %li
+        = link_to "Via GitHub", "/auth/github"
   - else
     %li.dropdown
       %a.dropdown-toggle{"data-toggle"=>"dropdown","role"=>"button","aria-haspopup"=>"true", "aria-expanded"=>"false" }
@@ -33,3 +35,5 @@
           = link_to "Via Twitter", "/auth/twitter"
         %li
           = link_to "Via Google", "/auth/google_oauth2"
+        %li
+          = link_to "Via GitHub", "/auth/github"

--- a/app/views/visitors/index.html.haml
+++ b/app/views/visitors/index.html.haml
@@ -27,6 +27,9 @@
         %a.btn.btn-block.btn-social.btn-google{:href => "/auth/google_oauth2"}
           %span.fa.fa-google
           Sign in with Google
+        %a.btn.btn-block.btn-social.btn-github{:href => "/auth/github"}
+          %span.fa.fa-github
+          Sign in with GitHub
     -#.col-md-4
   -#.row
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,4 +1,5 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :twitter, Rails.application.secrets.twitter_provider_key, Rails.application.secrets.twitter_provider_secret
   provider :google_oauth2, Rails.application.secrets.google_provider_key, Rails.application.secrets.google_provider_secret
+  provider :github, Rails.application.secrets.github_provider_key, Rails.application.secrets.github_provider_secret, scope: ""
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -15,6 +15,8 @@ development:
   twitter_provider_secret: <%= ENV["TWITTER_PROVIDER_SECRET"] %>
   google_provider_key: <%= ENV["GOOGLE_PROVIDER_KEY"] %>
   google_provider_secret: <%= ENV["GOOGLE_PROVIDER_SECRET"] %>
+  github_provider_key: <%= ENV["GITHUB_PROVIDER_KEY"] %>
+  github_provider_secret: <%= ENV["GITHUB_PROVIDER_SECRET"] %>
   domain_name: example.com
   secret_key_base: 499ed5cb646ed762eb3ef0c7e897e4faa3e79b683d7e6c83a1d33e79aac0b0b665915c7d457514b4960d8bb8448d80a863caf5c16b851be57a2192f6da202000
 
@@ -27,7 +29,9 @@ production:
   twitter_provider_key: <%= ENV["TWITTER_PROVIDER_KEY"] %>
   twitter_provider_secret: <%= ENV["TWITTER_PROVIDER_SECRET"] %>
   google_provider_key: <%= ENV["GOOGLE_PROVIDER_KEY"] %>
-  google_provider_secret: <%= ENV["GOOGLE_PROVIDER_SECRET"] %> 
+  google_provider_secret: <%= ENV["GOOGLE_PROVIDER_SECRET"] %>
+  github_provider_key: <%= ENV["GITHUB_PROVIDER_KEY"] %>
+  github_provider_secret: <%= ENV["GITHUB_PROVIDER_SECRET"] %>
   domain_name: <%= ENV["DOMAIN_NAME"] %>
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
 
@@ -35,6 +39,8 @@ staging:
   twitter_provider_key: <%= ENV["TWITTER_PROVIDER_KEY"] %>
   twitter_provider_secret: <%= ENV["TWITTER_PROVIDER_SECRET"] %>
   google_provider_key: <%= ENV["GOOGLE_PROVIDER_KEY"] %>
-  google_provider_secret: <%= ENV["GOOGLE_PROVIDER_SECRET"] %> 
+  google_provider_secret: <%= ENV["GOOGLE_PROVIDER_SECRET"] %>
+  github_provider_key: <%= ENV["GITHUB_PROVIDER_KEY"] %>
+  github_provider_secret: <%= ENV["GITHUB_PROVIDER_SECRET"] %>
   domain_name: <%= ENV["DOMAIN_NAME"] %>
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>

--- a/scripts/example-run-prod.sh
+++ b/scripts/example-run-prod.sh
@@ -4,10 +4,13 @@ export SECRET_KEY_BASE=secret-key
 
 export GOOGLE_PROVIDER_KEY='keyfromgoogle.apps.googleusercontent.com'
 export GOOGLE_PROVIDER_SECRET='secretfromgoogle'
+export GITHUB_PROVIDER_KEY='client id from https://github.com/settings/applications/new'
+export GITHUB_PROVIDER_SECRET='secret from https://github.com/settings/applications/new'
 
 HERE=$(pwd)
 
 docker run --env SECRET_KEY_BASE --env GOOGLE_PROVIDER_KEY --env GOOGLE_PROVIDER_SECRET \
+      --env GITHUB_PROVIDER_KEY --env GITHUB_PROVIDER_SECRET \
       --volume $HERE/docker-tmp/uploads:/opt/degust/uploads \
       --volume $HERE/docker-tmp/db:/opt/degust/db-file \
       --volume $HERE/docker-tmp/log:/opt/degust/log \


### PR DESCRIPTION
## Summary

This PR adds GitHub as an authentication provider using `omniauth-github` as a third alternative for users.